### PR TITLE
fix(frontend): Fix persistent loading animation in use-video hook

### DIFF
--- a/frontend/src/hooks/use-job-status.tsx
+++ b/frontend/src/hooks/use-job-status.tsx
@@ -97,7 +97,7 @@ export function useJobStatus({
         onErrorRef.current(jobStatus.error || "Job failed");
       }
     }
-  }, [jobStatus, queryClient, jobId]);
+  }, [jobStatus?.status, queryClient, jobId]);
 
   // Handle query errors
   useEffect(() => {

--- a/frontend/src/hooks/use-video.tsx
+++ b/frontend/src/hooks/use-video.tsx
@@ -126,7 +126,7 @@ export function useVideo(options?: GenerateVideoOptions) {
                 clearTimeoutRef.current = null;
             }
         };
-    }, [currentJobId, jobStatus?.jobStatus, jobStatus.error, jobCreationTime]);
+    }, [currentJobId, jobStatus?.jobStatus?.status, jobStatus.error, jobCreationTime]);
 
     const generateVideo = async ({ prompt, project_id }: GenerateVideoRequest) => {
         try {


### PR DESCRIPTION
The loading animation in the `use-video` hook was not being dismissed correctly after a video generation job was completed. This was caused by two related issues in the `useEffect` hooks in both `use-video.tsx` and `use-job-status.tsx`.

The `useEffect` hooks had objects in their dependency arrays (`jobStatus` and `jobStatus.jobStatus`). `useEffect` only re-runs if the object reference changes, not if a property of the object changes. This meant that when the job status was updated from 'processing' to 'completed', the effects were not re-triggered, and the state was not updated correctly.

This commit fixes the issue by changing the `useEffect` dependencies to depend on the primitive `status` property of the job status object (`jobStatus.status` and `jobStatus.jobStatus.status`). This ensures that the effects are correctly triggered when the job status changes, and the loading animation is dismissed as expected.